### PR TITLE
Simplified usage of GDrive.upload

### DIFF
--- a/utils/gdrivefile_util.py
+++ b/utils/gdrivefile_util.py
@@ -96,6 +96,7 @@ class GDrive:
             results = response.get('files', [])
             for file in results:
                 if file['name'] == file_name:
+                    logger.debug(f'{file_name}[{file["id"]}]')
                     return file['id']
             page_token = response.get('nextPageToken', None)
             if page_token is None:
@@ -122,9 +123,9 @@ class GDrive:
         while not done:
             status, done = downloader.next_chunk()
             if done:
-                logger.info(f'Downloading [{file_name}] completed.')
+                logger.info(f'Downloading {file_name}[{file_id}] completed.')
             else:
-                logger.info(f"Downloading [{file_name}] {str(int(status.progress() * 100))}%")
+                logger.info(f"Downloading {file_name}[{file_id}] {str(int(status.progress() * 100))}%")
 
     def get_folder_id(self, folder_name):
         # Search for folder id in Drive
@@ -147,26 +148,28 @@ class GDrive:
         if len(folders) > 1:
             logger.critical('Exists duplicate folders with the given name')
             raise FileNotFoundError(file_name)
-        folder_id = ''
-        for folder in folders:
-            folder_id = folder.get('id')
-        logger.info('Retrieved folder ID')
-        return folder_id
 
-    def upload_file(self, file_name, folder_name, file_path):
-        folder_id = self.get_folder_id(folder_name)
-        # Upload file to designated folder
-        file_metadata = {
-            'name': [file_name],
-            'parents': [folder_id]
-        }
-        media = MediaFileUpload(file_path,
-                                mimetype=guess_type(file_path)[0],
-                                resumable=True)
+        for folder in folders:
+            logger.debug(f'{folder_name}[{folder["id"]}]')
+            return folder["id"]
+
+    def upload_file(self, file_path, folder_name=None, file_name=None):
+        if file_name is None:
+            file_name = os.path.basename(file_path)
+        file_metadata = {'name': [file_name]}
+
+        if folder_name:
+            folder_id = self.get_folder_id(folder_name)
+            # Upload file to designated folder
+            file_metadata['parents'] = [folder_id]
+        if folder_name is None:
+            folder_name = 'RootDirectory'
+
+        media = MediaFileUpload(file_path, mimetype=guess_type(file_path)[0])
         file = self.drive.files().create(body=file_metadata,
-                                            media_body=media,
-                                            fields='id').execute()
-        logger.info(f"File {file_name} is uploaded to {folder_name} @ {file['id']}")
+                                         media_body=media,
+                                         fields='id, parents').execute()
+        logger.info(f"File {file_path} was uploaded to {folder_name}[{file['parents'][0]}] as {file_name}[{file['id']}]")
 
 
 if __name__ == '__main__':
@@ -174,7 +177,8 @@ if __name__ == '__main__':
 
     # Call the Drive v3 API
     file_name = 'ENV_GDRIVE_TEST.txt'
-    path = os.path.join('..', 'resources', 'sample_episodes', file_name)
+    path = os.path.join('..','resources', 'sample_episodes', file_name)
     drive.list_files()
-    #drive.download_file(file_name, path)
-    #drive.upload_file(path, None)
+    drive.download_file(file_name, path)
+    drive.upload_file(path)
+    drive.upload_file(path, file_name='differentname.txt', folder_name='Test2')


### PR DESCRIPTION
Used mimetype library to guess mimetype instead of explicitly specifying it
Added default values for folder name and file name: 
1. not specifying folder name will upload file to root directory of the drive.
2. not specifying file name will upload the file using the basename of the file